### PR TITLE
Added logs upload documentation

### DIFF
--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -10,8 +10,8 @@ Execution command for viewing logs of previous or current runs with pyATS.
       pyats logs <subcommand> [options]
 
     Subcommands:
-        view                open and view previous log archive or current run info in browser
         upload              upload a .zip pyATS archive to TaaS Logviewer
+        view                open and view previous log archive or current run info in browser
 
     General Options:
       -h, --help            Show help

--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -87,3 +87,43 @@ The following is an example of what the webpage looks like:
 
 Each tab shows the detailed results of each section of each testscript, as well
 as all commands executed and specific sections of logs.
+
+
+
+pyats logs upload
+---------------
+
+This subcommand will upload a zipped file to Taas Logviewer. It is an internal to 
+Cisco only feature.
+
+.. code-block:: text
+
+    Usage:
+      pyats logs upload [archive] [options]
+
+    Description:
+      Upload pyATS generated archive zip files to Taas Logviewer.
+
+      Examples:
+          # uploads an archive zip file to Taas Logviewer (default URL)
+          $ pyats logs upload file.zip
+
+          # uploads an archive zip file to the specified URL
+          $ pyats logs upload file.zip --upload-url http://someurl.com
+
+          # uploads an archive zip file to Taas Logviewer setting API timeout to 10 seconds
+          $ pyats logs upload file.zip --api-timeout 10
+
+          # uploads an archive zip file to custom URL setting API timeout to 10 seconds
+          $ pyats logs upload file.zip --upload-url http://someurl.com --api-timeout 10
+
+    Upload Options:
+      [archive/runinfo_dir] Archive zip file or runinfo directory to upload.
+      --upload-url [upload_url] URL to upload archive to.
+      --api-timeout [api_timeout] Set API timeout in seconds.
+
+    General Options:
+      -h, --help            Show help
+      -v, --verbose         Give more output, additive up to 3 times.
+      -q, --quiet           Give less output, additive up to 3 times, corresponding to WARNING, ERROR,
+                            and CRITICAL logging levels

--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -118,7 +118,7 @@ Cisco only feature.
           $ pyats logs upload file.zip --upload-url http://someurl.com --api-timeout 10
 
     Upload Options:
-      [archive/runinfo_dir] Archive zip file or runinfo directory to upload.
+      [archive/runinfo_dir] Archive zip file to upload.
       --upload-url [upload_url] URL to upload archive to.
       --api-timeout [api_timeout] Set API timeout in seconds.
 

--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -11,6 +11,7 @@ Execution command for viewing logs of previous or current runs with pyATS.
 
     Subcommands:
         view                open and view previous log archive or current run info in browser
+        upload              upload a .zip pyATS archive to TaaS Logviewer
 
     General Options:
       -h, --help            Show help

--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -94,7 +94,7 @@ as all commands executed and specific sections of logs.
 pyats logs upload
 ---------------
 
-This command will upload a .zip pyATS Archive to TaaS Logviewer. It is an internal to 
+This subcommand will upload a .zip pyATS Archive to TaaS Logviewer. It is an internal to 
 Cisco only feature.
 
 .. code-block:: text

--- a/docs/cli/pyats_logs.rst
+++ b/docs/cli/pyats_logs.rst
@@ -93,7 +93,7 @@ as all commands executed and specific sections of logs.
 pyats logs upload
 ---------------
 
-This subcommand will upload a zipped file to Taas Logviewer. It is an internal to 
+This command will upload a .zip pyATS Archive to TaaS Logviewer. It is an internal to 
 Cisco only feature.
 
 .. code-block:: text
@@ -106,16 +106,16 @@ Cisco only feature.
 
       Examples:
           # uploads an archive zip file to Taas Logviewer (default URL)
-          $ pyats logs upload file.zip
+          $ pyats logs upload basic_example_job.2021May17_16:23:14.753998.zip
 
           # uploads an archive zip file to the specified URL
-          $ pyats logs upload file.zip --upload-url http://someurl.com
+          $ pyats logs upload basic_example_job.2021May17_16:23:14.753998.zip --upload-url http://someurl.com
 
           # uploads an archive zip file to Taas Logviewer setting API timeout to 10 seconds
-          $ pyats logs upload file.zip --api-timeout 10
+          $ pyats logs upload basic_example_job.2021May17_16:23:14.753998.zip --api-timeout 10
 
           # uploads an archive zip file to custom URL setting API timeout to 10 seconds
-          $ pyats logs upload file.zip --upload-url http://someurl.com --api-timeout 10
+          $ pyats logs upload basic_example_job.2021May17_16:23:14.753998.zip --upload-url http://someurl.com --api-timeout 10
 
     Upload Options:
       [archive/runinfo_dir] Archive zip file to upload.


### PR DESCRIPTION
Added documentation to detail the new logs upload subcommand, which is only available for internal use at Cisco