### PR TITLE
Added URL option to yaml args

### DIFF
--- a/docs/aetest/run.rst
+++ b/docs/aetest/run.rst
@@ -544,12 +544,13 @@ arguments to ``aetest.main()`` and ``easypy.run()``.
         run(testscript = 'testscript.py', groups = And(Or('group1','group2'), 'group3'))
 
 ``datafile``, ``-datafile``
-    full name and path to the script input datafile file in YAML format. For
-    full detail on use cases and examples, refer to :ref:`aetest_datafile`.
+    full name and path or URL to the script input datafile file in YAML format. 
+    For full detail on use cases and examples, refer to :ref:`aetest_datafile`.
 
     .. code-block:: bash
 
         bash$ python testscript.py -datafile="/path/to/datafile.yaml"
+        bash$ python testscript.py -datafile="http://path.to/datafile.yaml"
 
     .. code-block:: python
 

--- a/docs/cli/pyats_validate.rst
+++ b/docs/cli/pyats_validate.rst
@@ -24,8 +24,8 @@ pyats validate testbed
 ----------------------
 
 This subcommand validates the content of your :ref:`topology_testbed_file`. It
-gives developer an opportunity to check whether the file written following valid
-YAML syntax, and adheres to the :ref:`schema`.
+gives developers an opportunity to check if the file is written following 
+valid YAML syntax, and adheres to the :ref:`schema`. 
 
 .. code-block:: text
 
@@ -45,7 +45,7 @@ Options
 ^^^^^^^
 
 ``[file]``
-    the input testbed yaml file.
+    the input testbed yaml file. Can be a file path or a URL to a YAML file
 
 ``--connect``
     best-effort attempt to connect to each testbed device using
@@ -92,11 +92,11 @@ pyats validate datafile
 
 This subcommand validates the content any pyATS YAML datafile, including 
 :ref:`aetest_datafile`. It understands the various YAML datafile syntaxes 
-introduced as part of pyATS's extended YAML loader, and gives developer an 
+introduced as part of pyATS's extended YAML loader, and gives developers an 
 opportunity to check:
 
 1. what the expanded data looks like
-2. whether correct YAML syntax is followed.
+2. if correct YAML syntax is followed
 
 Returns the loaded, validated datafile, with ``extends:`` block expanded.
 
@@ -128,7 +128,7 @@ Options
 ^^^^^^^
 
 ``[file]``
-    the input datafile.
+    the input datafile. Can be a file path or a URL to a YAML file
 
 ``--schema``
     Python module.object to the schema to validate the provided datafile against

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -160,6 +160,9 @@ The following fields are currently open for user to customize.
     # This can be inf, for no timeout, otherwise specify a number of seconds.
     timeout.time = <value>
 
+    # Maximum seconds to wait for a response when loading a YAML file from a URL
+    max_wait_time = <value>
+
     # configuration related to file transfer server
     [filetransfer]
 

--- a/docs/easypy/usages.rst
+++ b/docs/easypy/usages.rst
@@ -161,8 +161,8 @@ constructed and processed using python `argparse`_ module.  Please also see
     ``--configuration``, "configuration yaml file for plugins"
     ``--pyats-configuration``, "additional pyats configuration for execution"
     ``--job-uid``, "unique id from upper systems identifying this run"
-    ``--testbed-file``, "full path/name to YAML testbed file"
-    ``--clean-file``, "file containing :ref:`clean_file` information"
+    ``--testbed-file``, "full path/URL for YAML testbed file"
+    ``--clean-file``, "file path/URL to file containing :ref:`clean_file` information"
     ``--clean-devices``, "a list of devices to :ref:`clean<kleenex_index>`"
     ``--clean-scope``, "whether to perform :ref:`clean/bringup<kleenex_index>` at job or task level"
     ``--invoke-clean``, ":ref:`Clean<kleenex_cleaners>` is only invoked when this parameter is specified."
@@ -218,11 +218,12 @@ constructed and processed using python `argparse`_ module.  Please also see
 ``-C, --configuration``
     optional argument, used to provide the YAML plugin configuration file. Use
     this if you want to configure your Easypy to run certain plugins in custom
-    orders for this particular run.
+    orders for this particular run. Can be a file path or URL.
 
     .. code-block:: bash
 
         bash$ pyats run job /path/to/jobfile.py --configuration /path/to/config.yaml
+        bash$ pyats run job /path/to/jobfile.py --configuration "http://path.to/config.yaml"
 
 ``--job-uid``
     optional argument. Allows upstream executor (eg, Jenkins) to pass down
@@ -240,11 +241,11 @@ constructed and processed using python `argparse`_ module.  Please also see
         bash$ pyats run job /path/to/jobfile.py --pyats-configuration /path/to/my/pyats.conf
 
 ``--testbed-file``
-    Specifies the full path/name of YAML topology :ref:`topology_testbed_file`
-    to be loaded as part of this run. When used, Easypy automatically loads
-    the testbed yaml file into a topology :ref:`topology_objects`, and passes it
-    to each task inside the jobfiles as its ``testbed`` parameter. Refer to
-    :ref:`easypy_testbed` for more details.
+    Specifies the full path/name or URL of YAML topology 
+    :ref:`topology_testbed_file` to be loaded as part of this run. When used, 
+    Easypy automatically loads the testbed yaml file into a topology 
+    :ref:`topology_objects`, and passes it to each task inside the jobfiles as 
+    its ``testbed`` parameter. Refer to :ref:`easypy_testbed` for more details.
 
     Alternatively, you can specify a source to be loaded with the testbed
     creator package. To do so, append 'source:' in front of the desired loader
@@ -258,9 +259,10 @@ constructed and processed using python `argparse`_ module.  Please also see
         bash$ pyats run job /path/to/jobfile.py --testbed-file source:netbox
                                                 --netbox-token=token
                                                 --netbox-url=url
+        bash$ pyats run job /path/to/jobfile.py --testbed-file "http://path.to.my/testbed.yaml"
 
 ``--clean-file``
-    Full path to the clean file. This enables testbed cleaning using
+    Full path or URL to the clean file. This enables testbed cleaning using
     the :ref:`kleenex<kleenex_index>` module.  This option is only useable if
     testbed information is provided using ``--testbed-file`` argument.
 
@@ -268,6 +270,9 @@ constructed and processed using python `argparse`_ module.  Please also see
 
         bash$ pyats run job jobfile.py --testbed-file /path/to/mytestbed.yaml\
                                        --clean-file /path/to/clean.yaml
+                                       --invoke-clean
+        bash$ pyats run job jobfile.py --testbed-file "http://path.to.my/testbed.yaml"\
+                                       --clean-file "http://path.to/clean.yaml"
                                        --invoke-clean
 
 ``--clean-devices``

--- a/docs/topology/creation.rst
+++ b/docs/topology/creation.rst
@@ -18,9 +18,10 @@ There are two ways to create a topology within your testscript:
 .. hint::
 
     You can pass in a testbed YAML to ``pyats run job`` using the
-    ``--testbed-file`` option, which automatically invoke
+    ``--testbed-file`` option, which automatically invokes
     ``topology.loader`` to load the YAML file and pass the testbed object to
-    your script.
+    your script. The value following ``--testbed-file`` can be a file path or 
+    a URL.
 
 .. _topology_testbed_file:
 
@@ -33,13 +34,15 @@ convert the YAML description into testbed objects.
 
 .. code-block:: bash
 
-    # Example
-    # -------
+    # Examples
+    # --------
     #
-    #   starting a script using pyats run job and passing in testbed file
+    #   starting scripts using pyats run job and passing in testbed file/url
     #   using --testbed-file argument
 
     pyats run job jobfile.py --testbed-file /path/to/my/testbed/file/testbed.yaml
+    
+    pyats run job jobfile.py --testbed-file "https://path.to.my.testbed.com/testbed.yaml"
 
 Easypy then invokes ``topology`` module to load and convert this
 information into topology object instances, and pass it to the user script.
@@ -63,9 +66,9 @@ Internally, the following is really what happened:
     # voila!
 
 ``topology.loader.load()`` API takes in a loadable input (such as path to a YAML
-testbed file), parses the information, and makes appropriate Class constructor
-calls to construct the corresponding objects, including building the topology
-interconnect relationships.
+testbed file or a URL to a YAML testbed file), parses the information, and makes 
+appropriate Class constructor calls to construct the corresponding objects, 
+including building the topology interconnect relationships.
 
 Testbed files need to follow the standard testbed-file format (a.k.a schema).
 The :ref:`schema` controls how and what information can go into each testbed


### PR DESCRIPTION
Doc update for:
https://wwwin-github.cisco.com/pyATS/pyats/pull/217
https://wwwin-github.cisco.com/pyATS/genie/pull/140

Related PR for genie docs:
https://github.com/CiscoTestAutomation/genie/pull/35

Let's users know that they can use URLs for the following:

`pyats validate datafile`
`pyats validate testbed`
pyats.conf
--configuration
-datafile(aetest)
--testbed-file
--clean-file
