### PR TITLE
Document Clean retries after recovery

### DIFF
--- a/docs/kleenex/clean.rst
+++ b/docs/kleenex/clean.rst
@@ -156,6 +156,55 @@ The way a cleaner implementation indicates failure is by raising an exception
 inside its ``clean`` API.
 
 
+.. _kleenex_clean_recovery_retries:
+
+Recovery and Complete Clean Retries
+-----------------------------------
+
+When configured device recovery restores a device after a Clean stage fails or
+errors, Kleenex terminates the current device Clean attempt and starts a fresh
+attempt at the first configured stage. This behavior applies to recovery from
+any stage, including ``Connect``. Only the recovered device is retried; devices
+that completed successfully in the same parallel group are not cleaned again.
+
+A complete retry is requested only when the cleaner explicitly reports that
+recovery succeeded. A normal Clean failure, a reachable device for which
+recovery is unnecessary, or failed recovery does not trigger a retry.
+
+The retry budget is the number of additional attempts allowed after the
+initial attempt. It defaults to one and can be configured for standalone Clean
+with :ref:`the --clean-retries option <kleenex_clean_retries_option>`. For
+example, a value of ``2`` permits at most three attempts in total. The budget
+prevents a device that repeatedly requires recovery from extending Clean
+indefinitely. When the budget is exhausted, the final failed attempt determines
+the Clean result.
+
+Result Reporting
+^^^^^^^^^^^^^^^^
+
+Recovery success does not replace the result of the stage that caused
+recovery. The report keeps the original failed or errored stage, reports the
+recovery processor separately as passed, and blocks the remaining stages in
+that attempt.
+
+When another attempt is available, the failed attempt is retained in
+``results.json`` as an ignored, superseded device section and is excluded from
+the final result rollup. Retry sections use report identifiers such as
+``device_name [Retry 1]`` and separate log files such as
+``Kleenex.device_name.retry1.log``.
+
+If a retry and all remaining stages pass, the retry device and final Clean
+result are ``PASSX``. If a retry fails without another successful recovery, or
+successful recovery occurs after the configured retry budget is exhausted, the
+final attempt remains rollup-eligible and Clean fails. With
+``--clean-retries 0``, no retry is scheduled and the original failed attempt
+remains the final result even if recovery succeeds.
+
+Structured attempt, trigger, recovered-stage, and status information is stored
+under ``extra.clean_retry`` on each applicable device section in
+``results.json``.
+
+
 Clean Steps
 -----------
 

--- a/docs/kleenex/clean.rst
+++ b/docs/kleenex/clean.rst
@@ -167,6 +167,12 @@ attempt at the first configured stage. This behavior applies to recovery from
 any stage, including ``Connect``. Only the recovered device is retried; devices
 that completed successfully in the same parallel group are not cleaned again.
 
+For ``Connect`` specifically, this replaces the earlier behavior that changed
+a recovered Connect failure to ``PASSX`` and continued the same attempt. The
+failed Connect stage now keeps its original result, and successful recovery
+requests a fresh attempt, subject to the retry budget. One retry is allowed by
+default.
+
 A complete retry is requested only when the cleaner explicitly reports that
 recovery succeeded. A normal Clean failure, a reachable device for which
 recovery is unnecessary, or failed recovery does not trigger a retry.

--- a/docs/kleenex/usages.rst
+++ b/docs/kleenex/usages.rst
@@ -98,6 +98,7 @@ File Structure
     |-- Kleenex_2019Mar04_10:41:19.026530     -> kleenex logging directory
     .   |-- Kleenex.log                       -> Top level clean log
     .   |-- Kleenex.device_1.log              -> Device-specific clean log
+    .   |-- Kleenex.device_1.retry1.log       -> Device-specific retry log
     .   |-- Kleenex.device_2.log              -> Device-specific clean log
     .   |-- Kleenex.device_3.log              -> Device-specific clean log
         |-- env.txt                           -> environment debug information
@@ -114,6 +115,10 @@ Kleenex.log
 
 Kleenex.<device_name>.log
     Clean log: one per device that is cleaned.
+
+Kleenex.<device_name>.retry<N>.log
+    Clean log for retry ``N`` of a device. This file is created only when a
+    complete device Clean is retried after successful recovery.
 
 testbed.static.yaml
     Contents of the ``--testbed-file``, if specified by the user.
@@ -179,6 +184,7 @@ some exceptions.
     ``--testbed-file``, "testbed YAML file to load."
     ``--clean-file``, "YAML file(s) containing clean configuration details"
     ``--clean-devices``, "list of devices to clean"
+    ``--clean-retries``, "maximum number of complete device Clean retries after successful recovery; defaults to 1"
     ``--clean-device_image``, "space separated images per device with format device:/path/to/image.bin"
     ``--clean-os-image``, "space separated images per OS with format os:/path/to/image.bin"
     ``--clean-group-image``, "space separated images per group with format group:/path/to/image.bin"
@@ -255,6 +261,33 @@ some exceptions.
                                        --clean-file /path/to/my/clean.yaml\
                                        --clean-devices "[[device_a, device_b, device_c], [device_d, device_e]]"\
                                        --invoke-clean
+
+.. _kleenex_clean_retries_option:
+
+``--clean-retries``
+    specifies the maximum number of fresh, complete device Clean attempts that
+    may be scheduled after successful device recovery. The initial attempt is
+    not counted. For example, ``--clean-retries 2`` allows the initial attempt
+    plus at most two retries.
+
+    The value must be a non-negative integer and defaults to ``1``. Set it to
+    ``0`` to disable retry scheduling. Recovery may still succeed when retries
+    are disabled, but the original failed Clean remains the final result.
+
+    A retry starts at the first configured Clean stage and is scheduled only
+    for the recovered device. Ordinary Clean failures and failed recovery do
+    not trigger a retry. See :ref:`kleenex_clean_recovery_retries` for the full
+    behavior and result-reporting contract.
+
+    .. code-block:: bash
+
+        bash$ pyats clean --testbed-file /path/to/my/testbed.yaml\
+                          --clean-file /path/to/my/clean.yaml\
+                          --clean-retries 2
+
+    The legacy ``kleenex`` command accepts the equivalent
+    ``-clean_retries COUNT`` option. Programmatic integrations can pass the
+    same policy as ``KleenexMain(clean_retries=COUNT)``.
 
 ``--clean-device-image``
     specifies images to be used for clean per device. See


### PR DESCRIPTION
## Summary

- document full per-device Clean retries after successful recovery
- clarify that recovered Connect failures no longer become `PASSX` or continue the same attempt; they retain their result and request a fresh retry
- document `--clean-retries` defaults, disabled behavior, validation, and multiple-retry semantics
- document retry result rollup, `results.json` metadata, retry report identifiers, and retry log files
- include the legacy `-clean_retries` and programmatic `KleenexMain(clean_retries=...)` equivalents

## Validation

- `git diff --check`
- Sphinx HTML build completed successfully; both changed pages rendered with valid cross-references

The Sphinx build retains 43 existing environment/autodoc warnings unrelated to these pages.